### PR TITLE
Block paho-mqtt v2+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-paho-mqtt
+paho-mqtt<2
 requests


### PR DESCRIPTION
Current code doesn't work with paho-mqtt v2.0.0. This blocks pip from installing paho-mqtt v2.0.0 or greater (forces download of v1.6.1 currently).

Confirmed build and runs OK; connects to MQTT and serves events.